### PR TITLE
Add redirect from metronomeframeworks.com to metronome.llc

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "metronomeframeworks.com"
+        }
+      ],
+      "destination": "https://metronome.llc/$1",
+      "permanent": false
+    },
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.metronomeframeworks.com"
+        }
+      ],
+      "destination": "https://metronome.llc/$1",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` with 307 (temporary) redirects for both `metronomeframeworks.com` and `www.metronomeframeworks.com` → `metronome.llc`
- DNS for `metronome.llc` is confirmed working (Vercel nameservers active)
- `metronome.llc` is already assigned to the project and serving the same site

## Test plan
- [ ] Verify preview deployment shows redirect working on metronomeframeworks.com
- [ ] After merge, confirm live redirect on metronomeframeworks.com → metronome.llc
- [ ] When ready to fully migrate, update `permanent` to `true` in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)